### PR TITLE
Set pytest-cov version to fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIRED = [
     'pyperclip>=1.6.1<1.7.0',
 ]
 
-TESTS_REQUIRED = ["pytest", "pytest-cov", "mock; python_version < '3.4'", "keyrings.alt"]
+TESTS_REQUIRED = ["pytest", "pytest-cov<2.6", "mock; python_version < '3.7'", "keyrings.alt"]
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIRED = [
     'pyperclip>=1.6.1<1.7.0',
 ]
 
-TESTS_REQUIRED = ["pytest", "pytest-cov<2.6", "mock; python_version < '3.7'", "keyrings.alt"]
+TESTS_REQUIRED = ["pytest", "pytest-cov<2.6", "mock; python_version < '3.4'", "keyrings.alt"]
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Set pytest-cov version due to https://github.com/pytest-dev/pytest-cov/issues/257 breaking python versions older than 3.6