### PR TITLE
switch clipboard util, remove unsupported py versions from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 # ===== Linux ======
 dist: focal
 python:
-  - 3.6
   - 3.7
   - 3.8
   - 3.9
@@ -11,20 +10,6 @@ python:
 matrix:
   include:
     # ======= OSX ========
-    - name: "Python: 3.5"
-      os: osx
-      language: shell
-      python: 3.5
-      cache:
-        - directories:
-          - $HOME/Library/Caches/pip
-    - name: "Python: 3.6"
-      os: osx
-      language: shell
-      python: 3.6
-      cache:
-        - directories:
-          - $HOME/Library/Caches/pip
     - name: "Python: 3.7"
       os: osx
       language: shell
@@ -58,16 +43,6 @@ matrix:
     # NOTE: not all python versions are available on chocolatey on windows
     #
 
-    - name: "Python 3.6.8 on Windows"
-      os: windows
-      language: shell       # 'language: python' is an error on Travis CI Windows
-      before_install:
-        - choco install python --version 3.6.8
-        - python --version
-        - python -m pip install --upgrade pip
-        - pip3 install --upgrade pytest
-        - pip3 install codecov
-      env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
     - name: "Python 3.7.9 on Windows"
       os: windows
       language: shell       # 'language: python' is an error on Travis CI Windows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 keyring>=23.0.0,<24.0.0
 keyrings.alt>=4.1,<5.0
 pyotp>=2.6.0,<2.7.0
-pyperclip>=1.8.2,<1.9.0
+pyclip>=0.5.4,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     install_requires=REQUIRED,
     include_package_data=True,
     packages=['totp_generator'],
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     entry_points={
         'console_scripts': [
             'totp_generator = totp_generator.cli:main'

--- a/totp_generator/__init__.py
+++ b/totp_generator/__init__.py
@@ -1,3 +1,3 @@
 """TOTP Generator"""
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 __progname__ = 'TOTP Generator'

--- a/totp_generator/cli.py
+++ b/totp_generator/cli.py
@@ -26,7 +26,7 @@ import sys
 from typing import Union
 
 import keyring
-import pyperclip
+import pyclip
 
 import totp_generator
 from totp_generator.core_utils import KeyringTotpGenerator
@@ -277,7 +277,7 @@ def main():
                 print('')
 
         if args.copy:
-            pyperclip.copy(totp_code)
+            pyclip.copy(totp_code)
 
     except TypeError as err:
         print("Error generating TOTP code: {e}\n".format(e=err))


### PR DESCRIPTION
Drop py <3.7 from tests
Switch to pyclip and close https://github.com/jjfalling/TOTP-Generator/issues/4
Bump version to 3.1.0